### PR TITLE
Fix missing 'exports.types' field of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "exports": {
     ".": {
       "import": "./build/threejs-math.module.js",
-      "require": "./build/threejs-math.cjs"
+      "require": "./build/threejs-math.cjs",
+      "types": "./types/index.d.ts"
     }
   },
   "sideEffects": false,


### PR DESCRIPTION
In a recent project set up with Vite+Typescript, I installed threejs-math (`npm install threejs-math`) and imported some types: 

```
import { Vector2 } from "threejs-math";
``` 

But I got the following Typescript errors in my IDE (Sublime Text 4 with LSP-Typescript plugin):

```
There are types at `/home/boris/myproject/node_modules/threejs-math/types/index.d.ts`, but this result could not be resolved when respecting package.json "exports". The 'threejs-math' library may need to update its package.json or typings.
```

At first I thought it was probably a configuration problem of my project, my installation, or my IDE, but I couldn't fix it that way.

So following the suggestion of the error message, I looked online and found many projects having the same problem, which seems caused by the addition of new module resolution methods in recent versions of Typescript, see the following threads:

- https://github.com/microsoft/TypeScript/issues/52363
- https://github.com/gxmari007/vite-plugin-eslint/pull/60

The solution seems indeed to add the following to `threejs-math/package.json` :

```
{
  "exports": {
    ".": {
      "types": "./types/index.d.ts"
    }
  }
}
```

I tested this change and indeed it makes the error message go away in my case, and all types are now properly imported in my project.